### PR TITLE
Allow empty changelog on 'branch' (snapshot, not tag) release

### DIFF
--- a/.github/workflows/publish-workflow.yml
+++ b/.github/workflows/publish-workflow.yml
@@ -30,6 +30,7 @@ jobs:
           PRE_RELEASE: ${{ github.ref_type == 'branch' }}
           UNRELEASED: ${{ github.ref_type == 'branch' && 'update' || '' }}
           UNRELEASED_TAG: latest-snapshot
+          ALLOW_EMPTY_CHANGELOG: ${{ github.ref_type == 'branch' && 'true' || 'false' }}
         with:
           args: |
             build/*.jar


### PR DESCRIPTION
An empty changelog should be invalid when creating a new versioned release, though it seems fine to allow on snapshots. This should act as a ternary where branch builds allow empty changelogs but tag builds do not.

It also happens after each release as a consequence of releasing a snapshot/pre-release on every commit to master, where the release commit that moves changelog entries to the releasing version triggers a build that will then have an empty CHANGELOG. It also erroneously catches commits to master without changes "releasable" as failing the build.