### PR TITLE
Fix: Authenticate release workflow via SSH deploy key

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -23,16 +23,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: "${{ secrets.PAT }}"
+          ssh-key: "${{ secrets.COMMIT_KEY }}"
           fetch-depth: 0
+      - uses: webfactory/ssh-agent@v0.10.0
+        with:
+          ssh-private-key: ${{ secrets.COMMIT_KEY }}
       - uses: gradle/actions/setup-gradle@v6
       - name: Gradle Release
         if: ${{ inputs.versionIncrementer == 'default' }}
-        env:
-          DEPLOY_KEY: ${{ secrets.COMMIT_KEY }}
         run: ./gradlew release
       - name: Gradle Release w/ Increment Override
         if: ${{ inputs.versionIncrementer != 'default' }}
-        env:
-          DEPLOY_KEY: ${{ secrets.COMMIT_KEY }}
         run: ./gradlew release -Prelease.versionIncrementer=${{ inputs.versionIncrementer }}

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ssh-key: "${{ secrets.COMMIT_KEY }}"
           fetch-depth: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 - Update CI actions (checkout, artifact, setup-gradle, git-release) and runner image
 - Automate CHANGELOG release patching with the `org.jetbrains.changelog` plugin
 
+### Fixed
+- Release workflow authenticates via an SSH deploy key (`COMMIT_KEY`) instead of a stale PAT
+
 ## [0.2.0] - 2022-11-27
 ### Added
 - Separate publish and release creation action workflows


### PR DESCRIPTION
## Summary
- The `Create Release` workflow's `actions/checkout` step used `secrets.PAT`, a personal access token last updated in 2023 that had gone stale — causing `fatal: could not read Username for 'https://github.com': terminal prompts disabled` on fetch.
- A PAT (rather than the default `GITHUB_TOKEN`) is required here because pushes made with the default token don't trigger downstream workflows (needed so the new tag kicks off `Publish`).
- Switched to a repo-scoped SSH deploy key instead: `actions/checkout` now uses `ssh-key: secrets.COMMIT_KEY`, and `webfactory/ssh-agent@v0.10.0` loads the same key into an agent so axion-release can push the release tag/commit over SSH.
- Generated an ed25519 deploy keypair, registered the public half on the repo with write access, and set the private half as the `COMMIT_KEY` secret.
- Removed the `DEPLOY_KEY` env var — nothing in axion-release-plugin actually reads it, so it was dead config.

## Test plan
- [x] YAML syntax validated
- [x] Deploy key registered on the repo with write access (`gh api repos/dotRun/MCVotifierLib/keys`), confirmed via API response (`read_only: false`)
- [x] `COMMIT_KEY` secret set and confirmed present (`gh secret list`)

Next: re-run the `Create Release` workflow after merging to confirm the fix end-to-end.