### PR TITLE
Fix: Bump outdated actions/checkout, upload-artifact, and download-artifact

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: gradle/actions/setup-gradle@v6
@@ -23,7 +23,7 @@ jobs:
         id: version
         run: echo "version=$(./gradlew --console plain --quiet currentVersion -Prelease.quiet)" >> $GITHUB_OUTPUT
       - name: Upload build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build
           path: build/libs/*.jar

--- a/.github/workflows/publish-workflow.yml
+++ b/.github/workflows/publish-workflow.yml
@@ -13,12 +13,12 @@ jobs:
     name: Create Release
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: gradle/actions/setup-gradle@v6
       - name: Download build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build
           path: build


### PR DESCRIPTION
## Summary
- These three actions were left on v4 during the earlier CI modernization pass instead of their true current majors — `actions/checkout` v4 -> v7, `actions/upload-artifact` v4 -> v7, `actions/download-artifact` v4 -> v8.
- Checked release notes for every major in between for breaking changes relevant to our usage (`fetch-depth`, `name`, `path`, `retention-days`, `if-no-files-found`): the only changes were a Node 24 runtime bump (already met by GitHub-hosted runners), a fork-PR checkout restriction that only applies to `pull_request_target`/`workflow_run` triggers (unused here), and upload-artifact v7's opt-in unzipped-upload mode (not used) — confirmed compatible with download-artifact v8's default zipped-download handling.

## Test plan
- [x] YAML syntax validated for both changed workflow files
- [x] Verified via release notes that none of the inputs we set (`fetch-depth`, `name`, `path`, `retention-days`, `if-no-files-found`) changed behavior across the intervening majors