### PR TITLE
Fix: Register CHANGELOG.md as a commit pattern in the release hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixed
 - Release workflow authenticates via an SSH deploy key (`COMMIT_KEY`) instead of a stale PAT
+- Release commit now actually stages `CHANGELOG.md` (axion's commit hook only commits explicitly registered patterns, so the changelog patch was previously silently dropped)
 
 ## [0.2.0] - 2022-11-27
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,10 @@ scmVersion {
     versionIncrementer("incrementMinorIfNotOnRelease", mapOf("releaseBranchPattern" to "release/.+"))
 
     hooks {
-        pre { context: HookContext -> patchChangelogToVersion(context.releaseVersion) }
+        pre { context: HookContext ->
+            patchChangelogToVersion(context.releaseVersion)
+            context.addCommitPattern("CHANGELOG.md")
+        }
         pre("commit")
     }
 }


### PR DESCRIPTION
## Summary
- axion-release's built-in commit hook only stages files explicitly registered via `HookContext.addCommitPattern()` — it does not commit all working-tree changes, only what's registered.
- Our changelog-patching hook wrote `CHANGELOG.md` to disk but never registered it as a commit pattern, so the release commit ended up empty and the patched changelog was discarded.
- This is exactly what caused the real `v0.3.0` release to go out broken: the tag was created against an empty "Release version: 0.3.0" commit with `CHANGELOG.md` still showing `[Unreleased]`, which made the downstream `git-release` action fail (it couldn't find a "0.3.0" section) — no GitHub release or package was published for that tag.
- Fix: call `context.addCommitPattern("CHANGELOG.md")` alongside the existing `patchChangelogToVersion(context.releaseVersion)` call in the pre-release hook.

## Test plan
- [x] Reproduced and confirmed the root cause by inspecting the real failed run's logs and the actual (empty) release commit on `main`
- [x] Verified the fix end-to-end using axion's `release.localOnly` mode in an isolated git worktree off `main` (with the fix applied and a throwaway commit ahead of the last tag, so axion would compute a real next version): the resulting local release commit now includes the full `CHANGELOG.md` diff — new version header, moved unreleased entries, regenerated compare links — instead of being empty
- [x] `./gradlew clean build` passes