### PR TITLE
Fix: Empty changelog groups, silent-skip on empty release, and publish race

### DIFF
--- a/.github/workflows/publish-workflow.yml
+++ b/.github/workflows/publish-workflow.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          fetch-tags: true
       - uses: gradle/actions/setup-gradle@v6
       - name: Download build
         uses: actions/download-artifact@v8
@@ -34,7 +35,19 @@ jobs:
         with:
           args: |
             build/*.jar
+      - name: Check for tagged release
+        id: check_tag
+        run: |
+          if git tag --points-at HEAD | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "is_release_tag=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_release_tag=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Gradle Publish
+        # Both a branch push and its accompanying tag push trigger this workflow from the
+        # same release. Skip the branch-triggered run when it's also sitting on a release
+        # tag, so only the tag-triggered run publishes (avoids a duplicate-version 409).
+        if: ${{ !(github.ref_type == 'branch' && steps.check_tag.outputs.is_release_tag == 'true') }}
         run: ./gradlew publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,10 @@
 # Changelog
 
 ## [Unreleased]
-
-### Added
-
-### Changed
-
-### Deprecated
-
-### Removed
-
 ### Fixed
-
-### Security
+- Changelog plugin no longer pre-populates the new Unreleased section with empty Keep a Changelog group headers
+- Release hook now fails loudly (instead of silently skipping the whole release) if the Unreleased section has no content when a release runs
+- Publish workflow's registry publish step is skipped on the branch-triggered run when it's also sitting on a release tag, avoiding a duplicate-version 409 against the tag-triggered run
 
 ## [0.3.0] - 2026-07-22
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ scmVersion {
 
 changelog {
     repositoryUrl.set("https://github.com/dotRun/MCVotifierLib")
-    groups.set(listOf("Added", "Changed", "Deprecated", "Removed", "Fixed", "Security"))
+    groups.set(emptyList())
 }
 
 fun patchChangelogToVersion(newVersion: String) {
@@ -43,6 +43,7 @@ fun patchChangelogToVersion(newVersion: String) {
         .apply {
             version.set(newVersion)
             header.set("$newVersion - ${date()}")
+            patchEmpty.set(false)
         }.run()
 }
 


### PR DESCRIPTION
## Summary
- `changelog.groups` is now empty instead of the plugin's default 6-item Keep a Changelog list, so `patchChangelog` no longer stubs out empty `### Added / ### Changed / ...` headers in every new Unreleased section.
- Set `patchEmpty = false` on the `patchChangelog` task invoked from the release hook. Previously, if Unreleased had no content at release time, `PatchChangelogTask` threw `StopActionException`, which — since we call `.run()` directly instead of through Gradle's task graph — got silently swallowed, making the entire release a silent no-op (no commit, no tag, no push) while reporting `BUILD SUCCESSFUL`. Now it throws `MissingReleaseNoteException`, a real failure with a clear message.
- `publish-workflow.yml` triggers on both the branch push and the tag push from the same release, so two `Publish` runs fired concurrently and both tried to `gradlew publish` the same version — one 409s. Added a check-tag step and gated the `Gradle Publish` step to skip on the branch-triggered run when it's also sitting on a release tag, so only the tag-triggered run publishes.

## Test plan
- [x] `./gradlew clean build` passes
- [x] Verified `groups = emptyList()` in an isolated worktree via `release.localOnly`: the new Unreleased section has no stub headers, and existing Unreleased content correctly moved into the new version section (confirmed via `git show` diff on the resulting local commit)
- [x] Verified `patchEmpty = false` in an isolated worktree: with an empty Unreleased section, the release now fails loudly with `MissingReleaseNoteException` instead of silently producing no commit/tag/push while reporting success
- [x] `publish-workflow.yml` YAML syntax validated; the `if:` condition logic matches the described skip case (branch run + on a release tag) directly