### PR TITLE
Replace git-release Docker action with gh release + getChangelog

### DIFF
--- a/.github/workflows/publish-workflow.yml
+++ b/.github/workflows/publish-workflow.yml
@@ -23,18 +23,25 @@ jobs:
         with:
           name: build
           path: build
-      - name: Release
-        uses: docker://antonyurchenko/git-release:v6.0.0
+      - name: Extract release notes
+        run: |
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            ./gradlew getChangelog --console=plain -q --no-header --project-version="${{ needs.build.outputs.version }}" --output-file=build/release-notes.md
+          else
+            ./gradlew getChangelog --console=plain -q --no-header --unreleased --output-file=build/release-notes.md
+          fi
+      - name: Create GitHub release for tag
+        if: ${{ github.ref_type == 'tag' }}
+        run: gh release create "${{ github.ref_name }}" build/*.jar --title "${{ needs.build.outputs.version }}" --notes-file build/release-notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_NAME: ${{ needs.build.outputs.version }}
-          PRE_RELEASE: ${{ github.ref_type == 'branch' }}
-          UNRELEASED: ${{ github.ref_type == 'branch' && 'update' || '' }}
-          UNRELEASED_TAG: latest-snapshot
-          ALLOW_EMPTY_CHANGELOG: ${{ github.ref_type == 'branch' && 'true' || 'false' }}
-        with:
-          args: |
-            build/*.jar
+      - name: Update latest-snapshot pre-release
+        if: ${{ github.ref_type == 'branch' }}
+        run: |
+          gh release delete latest-snapshot --yes --cleanup-tag || true
+          gh release create latest-snapshot build/*.jar --title "${{ needs.build.outputs.version }}" --prerelease --notes-file build/release-notes.md --target "${{ github.sha }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Check for tagged release
         id: check_tag
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+- Replace the `antonyurchenko/git-release` Docker action with `gh release create`/`gh release delete`, using the `org.jetbrains.changelog` plugin's `getChangelog` task to extract release notes instead of a separate third-party changelog parser
+
 ### Fixed
 - Changelog plugin no longer pre-populates the new Unreleased section with empty Keep a Changelog group headers
 - Release hook now fails loudly (instead of silently skipping the whole release) if the Unreleased section has no content when a release runs


### PR DESCRIPTION
## Summary
- `antonyurchenko/git-release` hasn't been updated since Jan 2024 and runs its own independent Keep a Changelog parser, separate from the one already configured via `org.jetbrains.changelog` for patching — two different parsers for the same file risked them disagreeing on what counts as a valid section.
- Replaced it with plain `gh release create`/`gh release delete` (already available on runners, no Docker pull needed), fed by the changelog plugin's own `getChangelog` task:
  - Tag-triggered runs: `getChangelog --project-version=X` extracts that version's notes, `gh release create` publishes the tagged release.
  - Branch-triggered runs: `getChangelog --unreleased` extracts the current Unreleased content, and the `latest-snapshot` pre-release is deleted and recreated pointing at the new commit — the same "update in place" behavior `git-release` provided via its `PRE_RELEASE`/`UNRELEASED` env vars.

## Test plan
- [x] `./gradlew clean build` passes
- [x] Verified `getChangelog --no-header --output-file` locally for both the `--project-version=X` and `--unreleased` cases against the real changelog: clean section content, no header line, no reference-link footer — ready to use directly as release notes via `--notes-file`
- [x] `gh release create`/`gh release delete` flag usage (`--cleanup-tag`, `--target`, `--prerelease`, `--notes-file`, `--title`) confirmed against `gh release create --help`/`gh release delete --help`
- [x] YAML syntax validated

Since `publish-workflow.yml` only triggers on pushes (not PRs), the `gh release create`/`delete` steps themselves can only be exercised end-to-end by an actual push to `main` after merging — same as the verification approach used for the earlier release-workflow fixes in this session.