### PR TITLE
Chore: Consolidate today's work back into one Unreleased section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,11 @@
 # Changelog
 
 ## [Unreleased]
-
-## [0.2.1] - 2026-07-22
-
-### Changed
-
-- Replace the `antonyurchenko/git-release` Docker action with `gh release create`/`gh release delete`, using the `org.jetbrains.changelog` plugin's `getChangelog` task to extract release notes instead of a separate third-party changelog parser
-
-### Fixed
-
-- Changelog plugin no longer pre-populates the new Unreleased section with empty Keep a Changelog group headers
-- Release hook now fails loudly (instead of silently skipping the whole release) if the Unreleased section has no content when a release runs
-- Publish workflow's registry publish step is skipped on the branch-triggered run when it's also sitting on a release tag, avoiding a duplicate-version 409 against the tag-triggered run
-
-## [0.3.0] - 2026-07-22
-
 ### Added
-
 - Unit tests covering Jackson (de)serialization
 - Gradle version catalog (`gradle/libs.versions.toml`)
 
 ### Changed
-
 - Java 25
 - Kotlin 2.4.10
 - Update to Gradle 9
@@ -30,36 +13,34 @@
 - Bump Gradle plugins and dependencies
 - Update CI actions (checkout, artifact, setup-gradle, git-release) and runner image
 - Automate CHANGELOG release patching with the `org.jetbrains.changelog` plugin
+- Replace the `antonyurchenko/git-release` Docker action with `gh release create`/`gh release delete`, using the `org.jetbrains.changelog` plugin's `getChangelog` task to extract release notes instead of a separate third-party changelog parser
 
 ### Fixed
-
 - Release workflow authenticates via an SSH deploy key (`COMMIT_KEY`) instead of a stale PAT
 - Release commit now actually stages `CHANGELOG.md` (axion's commit hook only commits explicitly registered patterns, so the changelog patch was previously silently dropped)
+- Changelog plugin no longer pre-populates the new Unreleased section with empty Keep a Changelog group headers
+- Release hook now fails loudly (instead of silently skipping the whole release) if the Unreleased section has no content when a release runs
+- Publish workflow's registry publish step is skipped on the branch-triggered run when it's also sitting on a release tag, avoiding a duplicate-version 409 against the tag-triggered run
 
 ## [0.2.0] - 2022-11-27
-
 ### Added
-
 - Separate publish and release creation action workflows
 
 ### Changed
-
 - Java 17
 - Updated Actions CI with newer actions, shared build job, and snapshot releases
 - Update dependencies
 
 ### Fixed
-
 - Use maven-compatible version for dependencies (jackson `2.14.0` instead of `2.14.+`)
 
 ## [0.1.0] - 2020-06-04
-
 ### Added
-
 - Initial Release
 
-[Unreleased]: https://github.com/dotRun/MCVotifierLib/compare/v0.2.1...HEAD
-[0.3.0]: https://github.com/dotRun/MCVotifierLib/compare/v0.2.0...v0.3.0
-[0.2.1]: https://github.com/dotRun/MCVotifierLib/compare/v0.3.0...v0.2.1
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+[Unreleased]: https://github.com/dotRun/MCVotifierLib/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/dotRun/MCVotifierLib/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/dotRun/MCVotifierLib/commits/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Changelog
 
 ## [Unreleased]
+
 ### Added
+
 - Unit tests covering Jackson (de)serialization
 - Gradle version catalog (`gradle/libs.versions.toml`)
 
 ### Changed
+
 - Java 25
 - Kotlin 2.4.10
 - Update to Gradle 9
@@ -16,6 +19,7 @@
 - Replace the `antonyurchenko/git-release` Docker action with `gh release create`/`gh release delete`, using the `org.jetbrains.changelog` plugin's `getChangelog` task to extract release notes instead of a separate third-party changelog parser
 
 ### Fixed
+
 - Release workflow authenticates via an SSH deploy key (`COMMIT_KEY`) instead of a stale PAT
 - Release commit now actually stages `CHANGELOG.md` (axion's commit hook only commits explicitly registered patterns, so the changelog patch was previously silently dropped)
 - Changelog plugin no longer pre-populates the new Unreleased section with empty Keep a Changelog group headers
@@ -23,19 +27,25 @@
 - Publish workflow's registry publish step is skipped on the branch-triggered run when it's also sitting on a release tag, avoiding a duplicate-version 409 against the tag-triggered run
 
 ## [0.2.0] - 2022-11-27
+
 ### Added
+
 - Separate publish and release creation action workflows
 
 ### Changed
+
 - Java 17
 - Updated Actions CI with newer actions, shared build job, and snapshot releases
 - Update dependencies
 
 ### Fixed
+
 - Use maven-compatible version for dependencies (jackson `2.14.0` instead of `2.14.+`)
 
 ## [0.1.0] - 2020-06-04
+
 ### Added
+
 - Initial Release
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),


### PR DESCRIPTION
## Summary
- The `v0.2.1` and `v0.3.0` releases created earlier today were rolled back (GitHub releases, packages, and tags deleted) after a rebase orphaned the `v0.3.0` tag's commit, causing axion to compute the wrong next version (`0.2.1` instead of `0.3.1`).
- Merges the `[0.2.1]` and `[0.3.0]` sections back into `[Unreleased]` so the next release starts clean from a single, correctly-ordered version bump instead of split across two premature releases.
- Restored the Keep a Changelog/SemVer footer note, which had been silently dropped by the changelog plugin's patching (it only preserves versioned sections and the reference-link footer, not free-form prose between them).

## Test plan
- [x] `./gradlew clean build` passes
- [x] `./gradlew getChangelog --no-header --unreleased` confirmed the consolidated Unreleased section reads back correctly with all entries intact